### PR TITLE
fits 1.6.0 prep updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /*.log
 # Mac OS X system file
 .DS_Store
+/.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,41 @@
-  See https://github.com/harvard-lts/FITSservlet/wiki/FITS-Service-Releases-Notes
+# FITS Service Release Notes
+
+## Version 1.3.0 (TBD)
+- Update to FITS 1.6.0
+- Java 11 now required
+- Update Docker image
+
+## Version 1.2.0 (11/7/2018)
+- Converted the project to a Maven build.
+- Add a request parameter allowing "standard output" metadata to be suppressed. That is, the default result returned is as though running FITS with the -xc flag. Appending the request parameter `includeStandardOutput=false` to the FITS Service web application URL is the equivalent to not using the -xc flag.
+
+## Version 1.1.3 (9/13/16)
+- Error responses (HTTP 400, 500, etc.) are now returned as XML instead of plain text.
+- Allow a 0-length file as valid input; valid XML will be returned rather than a HTTP 400 code.
+- Exception stack traces now sent to log file. (Previously only the exception message was logged.)
+- Externalize servlet configuration values to a properties file. (See the [README](https://github.com/harvard-lts/FITSservlet#add-entries-to-catalinaproperties) section on pointing to this file from catalina.properties for more information.)
+- Fix mistake in 'curl' example in README file.
+
+## Version 1.1.2 (6/10/16)
+- Update licensing at top of source files for consistency across FITS project.
+- Update build for better access to fits.jar via either environment variable setting or fallback setting.
+- Removed duplication of JAR files that were put into the WAR's WEB-INF/lib directory by build.xml.
+
+## Version 1.1.1 (4/18/16)
+- Updated documentation.
+- Added 'description' attributes to a few Ant targets in build.xml.
+
+## Version 1.1.0 (4/15/16)
+- Implement POST handling of streaming file upload from any location.
+- Add Java test client - FormFileUploaderClientApplication.java - for testing POST functionality of Servlet.
+- Add script to exercise Java test client from terminal.
+- Built and tested with Java 8.
+
+## Version 1.0.0 (1/5/16)
+- Major refactoring.
+- This release is compatible only with FITS v.0.9.0 and later.
+- Removed all FITS project JAR files.
+- Removed WAR build artifact from source control.
+- FITS files runtime resolution via Tomcat or JBOSS classpath addition.
+- Created an Ant build file to create WAR artifact.
+- Initially only Servlet end point is GET HTTP request for local file upload.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FITS Service
-The FITS Service is a project that allows [FITS](http://fitstool.org) to be deployed as a service on either Tomcat or JBoss. The project has been built with Java 8.
-(It has been tested on Tomcat 7, Tomcat 8, and minimally tested on JBoss 7.1.)
+The FITS Service is a project that allows [FITS](http://fitstool.org) to be deployed as a service on either Tomcat or JBoss.
+The project has been built with Java 11. (It has been tested on Tomcat 7, Tomcat 8, and minimally tested on JBoss 7.1.)
 
 * <a href="#servlet-usage">FITS Web Service Usage Notes</a>
     * <a href="#endpoints">Endpoints</a>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,7 +62,7 @@ RUN unzip -q /opt/fits.zip -d /opt/fits && \
 
 # Install FITS Servlet into WebApps folder as ROOT.
 COPY target/fits-*.war $CATALINA_HOME/webapps/fits.war
-COPY docker/*.properties $CATALINA_HOME/conf
+COPY docker/*.properties $CATALINA_HOME/conf/
 RUN mkdir $CATALINA_HOME/webapps/ROOT && \
     echo '<% response.sendRedirect("/fits/"); %>' > $CATALINA_HOME/webapps/ROOT/index.jsp
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,18 +10,41 @@
 #   docker run --rm -it -p 8080:8080 fitsservlet
 #
 #   # Navigate to http://localhost:8080 in your browser
+FROM docker.io/tomcat:9-jre17-temurin-jammy
 
-FROM docker.io/tomcat:9-jre17-temurin-focal
-
-ARG FILE_VERSION=5.41
+ARG FILE_VERSION=5.43
+ARG FILE_SHA256=8c8015e91ae0e8d0321d94c78239892ef9dbc70c4ade0008c0e95894abfb1991
 
 RUN apt-get update && \
-    apt-get install -yqq make gcc unzip nano vim less && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -yqq \
+    unzip nano vim less \
+    # jpylyzer dependencies
+    python3 \
+    python-is-python3 \
+    # exiftool dependencies https://github.com/exiftool/exiftool
+    libarchive-zip-perl \
+    libio-compress-perl \
+    libcompress-raw-zlib-perl \
+    libcompress-bzip2-perl \
+    libcompress-raw-bzip2-perl \
+    libio-digest-perl \
+    libdigest-md5-file-perl \
+    libdigest-perl-md5-perl \
+    libdigest-sha-perl \
+    libposix-strptime-perl \
+    libunicode-linebreak-perl\
+    # file dependencies
+    make \
+    gcc \
+    # mediainfo dependencies
+    libmms0 \
+    libcurl3-gnutls \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install file https://github.com/file/file
 RUN cd /var/tmp && \
     curl -so file-${FILE_VERSION}.tar.gz https://astron.com/pub/file/file-${FILE_VERSION}.tar.gz && \
+    echo "${FILE_SHA256}  file-${FILE_VERSION}.tar.gz" | sha256sum --check && \
     tar xzf file-${FILE_VERSION}.tar.gz && \
     cd file-${FILE_VERSION} && \
     ./configure && \

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.harvard.huit.lts</groupId>
 	<artifactId>fits-service</artifactId>
-	<version>1.2.4-SNAPSHOT</version>
+	<version>1.3.0-SNAPSHOT</version>
 	<packaging>war</packaging>
 
 	<name>FITS Service</name>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<fits.version>1.5.2-SNAPSHOT</fits.version>
+		<fits.version>1.6.0-SNAPSHOT</fits.version>
 	</properties>
 	
 	<build>
@@ -24,8 +24,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.10.1</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>11</source>
+					<target>11</target>
 					<showDeprecation>true</showDeprecation>
 					<showWarnings>true</showWarnings>
 				</configuration>
@@ -108,12 +108,12 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.17.1</version>
+			<version>2.19.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.17.1</version>
+			<version>2.19.0</version>
 		</dependency>
 		<!--
 			The following are necessary beginning with JDK 11 (or OpenJDK 11)


### PR DESCRIPTION
1. Update FITS version to 1.6.0-SNAPSHOT
2. Update Java version to 11
3. Update Dockerfile to reflect 1.6.0 requirements
4. Changed the version to 1.3.0-SNAPSHOT

I resisted doing any other cleanup, and used the [Docker setup](https://github.com/harvard-lts/FITSservlet#docker) for testing.